### PR TITLE
hisi-idt.py: use python3 as python2 is EOL January 2020.

### DIFF
--- a/hisi-idt.py
+++ b/hisi-idt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #-*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Signed-off-by: Peter Griffin <peter.griffin@linaro.org>